### PR TITLE
added missing class to legend

### DIFF
--- a/app/views/v1/selectpermit/permit-category.html
+++ b/app/views/v1/selectpermit/permit-category.html
@@ -25,7 +25,7 @@
       <form method="post" action="{{formAction}}" class="form">
         <div class="form-group">
           <fieldset aria-labelledby="radio_label">
-            <legend="Permit type">
+            <legend class="Permit type">
             
             {% for c in categories %}
               {% if c.digitalMVP=="Yes" %}

--- a/app/views/v2/selectpermit/permit-category.html
+++ b/app/views/v2/selectpermit/permit-category.html
@@ -25,7 +25,7 @@
       <form method="post" action="{{formAction}}" class="form">
         <div class="form-group">
           <fieldset aria-labelledby="radio_label">
-            <legend="Permit type">
+            <legend class="Permit type">
             
             {% for c in categories %}
               {#% if c.digitalMVP=="Yes" %#}

--- a/app/views/v2a/selectpermit/permit-category.html
+++ b/app/views/v2a/selectpermit/permit-category.html
@@ -25,7 +25,7 @@
       <form method="post" action="{{formAction}}" class="form">
         <div class="form-group">
           <fieldset aria-labelledby="radio_label">
-            <legend="Permit type">
+            <legend class="Permit type">
             
             {% for c in categories %}
               {#% if c.digitalMVP=="Yes" %#}

--- a/app/views/v3/selectpermit/permit-category.html
+++ b/app/views/v3/selectpermit/permit-category.html
@@ -25,7 +25,7 @@
       <form method="post" action="{{formAction}}" class="form">
         <div class="form-group">
           <fieldset aria-labelledby="radio_label">
-            <legend="Permit type">
+            <legend class="Permit type">
             
             {% for c in categories %}
               {#% if c.digitalMVP=="Yes" %#}

--- a/app/views/v4/selectpermit/permit-category.html
+++ b/app/views/v4/selectpermit/permit-category.html
@@ -25,7 +25,7 @@
       <form method="post" action="{{formAction}}" class="form">
         <div class="form-group">
           <fieldset aria-labelledby="radio_label">
-            <legend="Permit type">
+            <legend class="Permit type">
             
             {% for c in categories %}
               {#% if c.digitalMVP=="Yes" %#}

--- a/app/views/v5/selectpermit/permit-category.html
+++ b/app/views/v5/selectpermit/permit-category.html
@@ -25,7 +25,7 @@
       <form method="post" action="{{formAction}}" class="form">
         <div class="form-group">
           <fieldset aria-labelledby="radio_label">
-            <legend="Permit type">
+            <legend class="Permit type">
             
             {% for c in categories %}
               {#% if c.digitalMVP=="Yes" %#}

--- a/app/views/v6/selectpermit/permit-category.html
+++ b/app/views/v6/selectpermit/permit-category.html
@@ -25,7 +25,7 @@
       <form method="post" action="{{formAction}}" class="form">
         <div class="form-group">
           <fieldset aria-labelledby="radio_label">
-            <legend="Permit type">
+            <legend class="Permit type">
 
         {% for c in categories %}
 

--- a/app/views/v6/selectpermit/permit-category2.html
+++ b/app/views/v6/selectpermit/permit-category2.html
@@ -25,7 +25,7 @@
       <form method="post" action="{{formAction}}" class="form">
         <div class="form-group">
           <fieldset aria-labelledby="radio_label">
-            <legend="Permit type">
+            <legend class="Permit type">
 
         {% for c in categories %}
 


### PR DESCRIPTION
There was a missing class from the legend HTML on the permit selection screens. This was causing a bug on the pointer display for radio elements.